### PR TITLE
Disable automatic setting of item and pos emoticons in the config

### DIFF
--- a/src/main/java/eu/pb4/styledchat/config/data/ConfigData.java
+++ b/src/main/java/eu/pb4/styledchat/config/data/ConfigData.java
@@ -80,17 +80,6 @@ public class ConfigData {
             configData.defaultEnabledFormatting.putIfAbsent(entry.getKey(), entry.getValue());
         }
 
-        if (configData.defaultEnabledFormatting.get(StyledChatUtils.ITEM_TAG)) {
-            configData.defaultEnabledFormatting.remove(StyledChatUtils.ITEM_TAG);
-            configData.emoticons.put(StyledChatUtils.ITEM_TAG, "[%player:equipment_slot/mainhand%]");
-        }
-
-        if (configData.defaultEnabledFormatting.get(StyledChatUtils.POS_TAG)) {
-            configData.defaultEnabledFormatting.remove(StyledChatUtils.POS_TAG);
-            configData.emoticons.put(StyledChatUtils.POS_TAG, "%player:pos_x% %player:pos_y% %player:pos_z%");
-        }
-
-
         for (var entry : configData.permissionEmoticons) {
             if (entry.emotes != null) {
                 entry.emoticons = entry.emotes;


### PR DESCRIPTION
When you change or delete **pos** emoticon or **item** emoticon from the config, their values will automatically change to the default