### PR TITLE
Retrieve normal message content for mod compatibility

### DIFF
--- a/src/main/java/eu/pb4/styledchat/other/StyledChatSentMessage.java
+++ b/src/main/java/eu/pb4/styledchat/other/StyledChatSentMessage.java
@@ -33,7 +33,7 @@ public interface StyledChatSentMessage extends SentMessage, ExtendedSentMessage 
 
     record Chat(SignedMessage message, Text override, MessageType.Parameters parameters, RegistryKey<MessageType> sourceType, MutableObject<MessageType.Parameters> colorless) implements StyledChatSentMessage {
         public Text content() {
-            return message.unsignedContent();
+            return message.getContent();
         }
 
         @Override
@@ -75,7 +75,7 @@ public interface StyledChatSentMessage extends SentMessage, ExtendedSentMessage 
 
     record System(SignedMessage message, Text override, MessageType.Parameters parameters, RegistryKey<MessageType> sourceType, MutableObject<MessageType.Parameters> colorless) implements StyledChatSentMessage {
         public Text content() {
-            return this.message.unsignedContent();
+            return this.message.getContent();
         }
 
         @Override


### PR DESCRIPTION
I discovered that `unsignedContent` was returning `null` on my server, which causes mixins downstream (namely those used by Chat Control by declipsonator) to throw NullPointerExceptions.

Using getContent() instead fixes this! This change allows seamless integration with Chat Control and maybe other chat mods.